### PR TITLE
修正手机验证码可绕过的问题

### DIFF
--- a/catalog/controller/account/register.php
+++ b/catalog/controller/account/register.php
@@ -344,13 +344,10 @@ class ControllerAccountRegister extends Controller {
 					$this->error['telephone'] = $this->language->get('error_telephone_exists');
 				} else {
 					// if sms code is not correct
-					if (isset($this->request->post['sms_code'])) {
-						$this->load->model('account/smsmobile');
-						if($this->model_account_smsmobile->verifySmsCode($this->request->post['telephone'], $this->request->post['sms_code']) == 0) {
-							$this->error['sms_code'] = $this->language->get('error_sms_code');
-						}
+					$this->load->model('account/smsmobile');
+					if($this->model_account_smsmobile->verifySmsCode($this->request->post['telephone'], $this->request->post['sms_code']) == 0) {
+						$this->error['sms_code'] = $this->language->get('error_sms_code');
 					}
-				
 				}
 				
 			}


### PR DESCRIPTION
在之前的版本中时用isset来判断sms code 的，如果前端直接把html form表单里的sms code一项删除，然后提交，那么不用填手机的验证码就能通过注册。因为没有sms_code这个post项，isset不成立，也就不对sms_code进行验证，显然这是不合理的。如要要更进一步，为了严谨，不报warning，可以在判断没有这个sms_code项时，报一个“手机验证码未填写“的error